### PR TITLE
Adding support for IAM based credentials, customizable stream name.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,7 +66,6 @@ class cloudwatchlogs (
       package { 'awslogs':
         ensure => 'present',
         before => File['/etc/awslogs/awslogs.conf'],
-        ],
       }
 
       file { '/etc/awslogs/awslogs.conf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,9 @@
 # [*region*]
 #   The region your EC2 instance is running in.
 #
+# [*streamname*]
+#   The name of the stream in CW Logs. Defaults to instance-id.
+#
 # [*aws_access_key_id*]
 #   The Access Key ID from the IAM user that has access to Cloudwatch Logs.
 #
@@ -46,6 +49,7 @@ class cloudwatchlogs (
   $region                = $::cloudwatchlogs::params::region,
   $aws_access_key_id     = $::cloudwatchlogs::params::aws_access_key_id,
   $aws_secret_access_key = $::cloudwatchlogs::params::aws_secret_access_key,
+  $streamname            = $::cloudwatchlogs::params::streamname,
 
 ) inherits cloudwatchlogs::params {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,42 +51,50 @@ class cloudwatchlogs (
 
   validate_absolute_path($state_file)
   validate_array($logs)
-  validate_string($region)
-  validate_string($aws_access_key_id)
-  validate_string($aws_secret_access_key)
+  if $region {
+    validate_string($region)
+  }
+  if $aws_access_key_id {
+    validate_string($aws_access_key_id)
+  }
+  if $aws_secret_access_key {
+    validate_string($aws_secret_access_key)
+  }
 
   case $::operatingsystem {
     'Amazon': {
       package { 'awslogs':
         ensure => 'present',
-        before => [
-          File['/etc/awslogs/awslogs.conf'],
-          File['/etc/awslogs/awscli.conf'],
+        before => File['/etc/awslogs/awslogs.conf'],
         ],
       }
+
       file { '/etc/awslogs/awslogs.conf':
-        ensure => 'file',
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0644',
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
         content => template('cloudwatchlogs/awslogs.conf.erb'),
       }
-      file { '/etc/awslogs/awscli.conf':
-        ensure => 'file',
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0644',
-        content => template('cloudwatchlogs/awscli.conf.erb'),
+
+      if $region and $aws_access_key_id and $aws_secret_access_key {
+        file { '/etc/awslogs/awscli.conf':
+          ensure  => 'file',
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0644',
+          require => Package['awslogs'],
+          notify  => Service['awslogs'],
+          content => template('cloudwatchlogs/awscli.conf.erb'),
+        }
       }
+
       service { 'awslogs':
         ensure     => 'running',
         enable     => true,
         hasrestart => true,
         hasstatus  => true,
-        subscribe  => [
-          File['/etc/awslogs/awslogs.conf'],
-          File['/etc/awslogs/awscli.conf'],
-        ],
+        subscribe  => File['/etc/awslogs/awslogs.conf'],
       }
     }
     /^(Ubuntu|CentOS|RedHat)$/: {
@@ -118,7 +126,6 @@ class cloudwatchlogs (
         require => File['/var/awslogs'],
         before  => [
           File['/var/awslogs/etc/awslogs.conf'],
-          File['/var/awslogs/etc/awscli.conf'],
         ],
       }
       file { '/etc/awslogs/awslogs.conf':
@@ -136,12 +143,16 @@ class cloudwatchlogs (
         mode    => '0644',
         content => template('cloudwatchlogs/awslogs.conf.erb'),
       }
-      file { '/var/awslogs/etc/awscli.conf':
-        ensure  => 'file',
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0644',
-        content => template('cloudwatchlogs/awscli.conf.erb'),
+      if $region and $aws_access_key_id and $aws_secret_access_key {
+        file { '/var/awslogs/etc/awscli.conf':
+          ensure  => 'file',
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0644',
+          require => File['/var/awslogs/etc'],
+          notify  => Service['awslogs'],
+          content => template('cloudwatchlogs/awscli.conf.erb'),
+        }
       }
       exec { 'cloudwatchlogs-install':
         path    => '/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin',
@@ -156,10 +167,7 @@ class cloudwatchlogs (
         enable     => true,
         hasrestart => true,
         hasstatus  => true,
-        subscribe  => [
-          File['/var/awslogs/etc/awslogs.conf'],
-          File['/var/awslogs/etc/awscli.conf'],
-        ],
+        subscribe  => File['/var/awslogs/etc/awslogs.conf'],
       }
     }
     default: { fail("The ${module_name} module is not supported on ${::osfamily}/${::operatingsystem}.") }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,5 +12,6 @@ class cloudwatchlogs::params {
   $region                = undef
   $aws_access_key_id     = undef
   $aws_secret_access_key = undef
+  $streamname            = '{instance-id}'
 
 }

--- a/templates/awslogs.conf.erb
+++ b/templates/awslogs.conf.erb
@@ -2,7 +2,7 @@
 state_file = <%= @state_file %>
 
 <% @logs.each do |log| -%>
-<% log.sort.map do |name,path| -%>
+<% log.map do |name,path| -%>
 [<%= name %>]
 datetime_format = %b %d %H:%M:%S
 file = <%= path %>

--- a/templates/awslogs.conf.erb
+++ b/templates/awslogs.conf.erb
@@ -2,12 +2,12 @@
 state_file = <%= @state_file %>
 
 <% @logs.each do |log| -%>
-<% log.map do |name,path| -%>
+<% log.each do |name,path| -%>
 [<%= name %>]
 datetime_format = %b %d %H:%M:%S
 file = <%= path %>
 buffer_duration = 5000
-log_stream_name = {instance_id}
+log_stream_name = <%= @streamname %>
 initial_position = start_of_file
 log_group_name = <%= name %>
 <% end -%>


### PR DESCRIPTION
As it says....  I made region, secret key, and access key id optional and assume IAM roles will be available if not provided. I also made streamname a variable that defaults to {instance-id} so that you can supply an alternate one at the class level. I suppose this could be modded to be at the log level, but that's for another day.

Also, I removed the "log.sort.map" as I'm not entirely sure why a single hash should be sorted and then mapped... If there's a good reason, reject and I'll put it back.