### PR TITLE
quotes incorrect around keys for awscli

### DIFF
--- a/templates/awscli.conf.erb
+++ b/templates/awscli.conf.erb
@@ -1,6 +1,6 @@
 [default]
 region = <%= @region %>
-aws_access_key_id = '<%= @aws_access_key_id %>'
-aws_secret_access_key = '<%= @aws_secret_access_key %>'
+aws_access_key_id = <%= @aws_access_key_id %>
+aws_secret_access_key = <%= @aws_secret_access_key %>
 [plugins]
 cwlogs = cwlogs


### PR DESCRIPTION
quotes incorrect around keys for awscli to be the aws_config_file for awscli