### PR TITLE
Support the aws cloudwatch option "multi_line_start_pattern"

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ Default: *Resource Name*
 
 Specifies the destination log group. A log group will be created automatically if it doesn't already exist.
 
+#### `multi_line_start_pattern`
+
+Default: `undef`
+
+Optional. This is a regex string that identifies the start of a log line. See [the official docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/AgentReference.html) for further info.
+
 ## Http Proxy Usage
 
 If you have a http_proxy or https_proxy then run the following puppet code after calling cloudwatchlogs to modify the launcher script as a workaround bcause awslogs python code currently doesn't have http_proxy support:

--- a/manifests/log.pp
+++ b/manifests/log.pp
@@ -3,6 +3,7 @@ define cloudwatchlogs::log (
   $streamname      = '{instance_id}',
   $datetime_format = '%b %d %H:%M:%S',
   $log_group_name  = undef,
+  $multi_line_start_pattern = undef,
 
 ){
   if $path == undef {
@@ -20,6 +21,7 @@ define cloudwatchlogs::log (
   validate_string($streamname)
   validate_string($datetime_format)
   validate_string($real_log_group_name)
+  validate_string($multi_line_start_pattern)
 
   concat::fragment { "cloudwatchlogs_fragment_${name}":
     target  => '/etc/awslogs/awslogs.conf',

--- a/templates/awslogs_log.erb
+++ b/templates/awslogs_log.erb
@@ -5,3 +5,6 @@ buffer_duration = 5000
 log_stream_name = <%= @streamname %>
 initial_position = start_of_file
 log_group_name = <%= @real_log_group_name %>
+<% if @multi_line_start_pattern %>
+multi_line_start_pattern <%= @multi_line_start_pattern %>
+<% end %>

--- a/templates/awslogs_log.erb
+++ b/templates/awslogs_log.erb
@@ -6,5 +6,5 @@ log_stream_name = <%= @streamname %>
 initial_position = start_of_file
 log_group_name = <%= @real_log_group_name %>
 <% if @multi_line_start_pattern %>
-multi_line_start_pattern <%= @multi_line_start_pattern %>
+multi_line_start_pattern = <%= @multi_line_start_pattern %>
 <% end %>


### PR DESCRIPTION
This is a regex pattern that identifies the start of a log line. Very helpful when dealing with oddly formed log files. See more info here: http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/AgentReference.html

I think I got everything necessary to support this feature. It might be good to include an example.