### PR TITLE
metadata: update dependency format to match as expected

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 3.2.0"},
-    {"name":"puppetlabs-concat","version_requirement":">= 1.1.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0"},
+    {"name":"puppetlabs/concat","version_requirement":">= 1.1.0"}
   ]
 }


### PR DESCRIPTION
`creator/module` is the format expected for the dependencies list, which is confusing since the modules are referred to by `creator-module` when using the `puppet module` commands.