### PR TITLE
Concatenate config before install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,10 @@ class cloudwatchlogs (
           command => "python /usr/local/src/awslogs-agent-setup.py -n -r ${region} -c /etc/awslogs/awslogs.conf",
           onlyif  => '[ -e /usr/local/src/awslogs-agent-setup.py ]',
           unless  => '[ -d /var/awslogs/bin ]',
-          require => Exec['cloudwatchlogs-wget'],
+          require => [
+            Concat['/etc/awslogs/awslogs.conf'],
+            Exec['cloudwatchlogs-wget']
+          ],
           before  => [
             Service['awslogs'],
             File['/var/awslogs/etc/awslogs.conf'],


### PR DESCRIPTION
Something changed somewhere upstream and now the installation script on Ubuntu needs the `/etc/awslogs/awslogs.conf` file to be present. This is the error:

```
Notice: Compiled catalog for .................... in environment production in 1.27 seconds
Info: Applying configuration version '1458762522'
Notice: /Stage[main]/Cloudwatchlogs/File[/etc/awslogs]/ensure: created
Notice: /Stage[main]/Cloudwatchlogs/File[/var/awslogs]/ensure: created
Notice: /Stage[main]/Cloudwatchlogs/File[/var/awslogs/etc]/ensure: created
Notice: /Stage[main]/Cloudwatchlogs/Exec[cloudwatchlogs-install]/returns:
Notice: /Stage[main]/Cloudwatchlogs/Exec[cloudwatchlogs-install]/returns: Step 1 of 5: Installing pip ...DONE
Notice: /Stage[main]/Cloudwatchlogs/Exec[cloudwatchlogs-install]/returns:
Notice: /Stage[main]/Cloudwatchlogs/Exec[cloudwatchlogs-install]/returns: Step 2 of 5: Downloading the latest CloudWatch Logs agent bits ... DONE
Notice: /Stage[main]/Cloudwatchlogs/Exec[cloudwatchlogs-install]/returns:
Notice: /Stage[main]/Cloudwatchlogs/Exec[cloudwatchlogs-install]/returns: ERROR: Config file /etc/awslogs/awslogs.conf doesn't exist.
Error: python /usr/local/src/awslogs-agent-setup.py -n -r us-east-1 -c /etc/awslogs/awslogs.conf returned 4 instead of one of [0]
Error: /Stage[main]/Cloudwatchlogs/Exec[cloudwatchlogs-install]/returns: change from notrun to 0 failed: python /usr/local/src/awslogs-agent-setup.py -n -r us-east-1 -c /etc/awslogs/awslogs.conf returned 4 instead of one of [0]
Notice: /Stage[main]/Cloudwatchlogs/Concat[/etc/awslogs/awslogs.conf]/File[/etc/awslogs/awslogs.conf]/ensure: defined content as '{md5}40934157d318643325c091062d793423'
Info: Concat[/etc/awslogs/awslogs.conf]: Scheduling refresh of Service[awslogs]
Notice: /Stage[main]/Cloudwatchlogs/File[/var/awslogs/etc/awslogs.conf]: Dependency Exec[cloudwatchlogs-install] has failures: true
Warning: /Stage[main]/Cloudwatchlogs/File[/var/awslogs/etc/awslogs.conf]: Skipping because of failed dependencies
Notice: /Stage[main]/Cloudwatchlogs/Service[awslogs]: Dependency Exec[cloudwatchlogs-install] has failures: true
Warning: /Stage[main]/Cloudwatchlogs/Service[awslogs]: Skipping because of failed dependencies
Info: /Stage[main]/Cloudwatchlogs/Service[awslogs]: Unscheduling all events on Service[awslogs]
Info: Class[Cloudwatchlogs]: Unscheduling all events on Class[Cloudwatchlogs]
Notice: Applied catalog in 14.75 seconds
```

This PR creates a relationship between the installation script and the concatenation.