### PR TITLE
add compartmentalise log file configuration into /etc/awslogs/config/

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ cloudwatchlogs::log { 'Secure':
 }
 ```
 
+Another example that might be used on the RedHat *::osfamily* to create individual log config files in /etc/awslogs/config/ is:
+
+```puppet
+class { '::cloudwatchlogs': region => 'eu-west-1' }
+
+cloudwatchlogs::compartment_log { 'Access':
+  path => '/var/log/httpd/access_logs',
+}
+cloudwatchlogs::compartment_log { 'Error':
+  path => '/var/log/httpd/error_logs',
+}
+```
+
+
 Alternatively logs can be defined as part of the main `cloudwatchlogs` class:
 
 ```puppet

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ cloudwatchlogs::compartment_log { 'Error':
 }
 ```
 
-
 Alternatively logs can be defined as part of the main `cloudwatchlogs` class:
 
 ```puppet

--- a/examples/compartment_log.pp
+++ b/examples/compartment_log.pp
@@ -1,0 +1,10 @@
+# Assumes Amazon Linux
+#See here for more info about compartmentalization: (http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/AgentReference.html#d0e24912)
+include '::cloudwatchlogs'
+
+cloudwatchlogs::compartment_log { 'AccessLogs':
+  path => '/var/log/httpd/access_log',
+}
+cloudwatchlogs::compartment_log { 'ErrorLogs':
+  path => '/var/log/httpd/error_log',
+}

--- a/manifests/compartment_log.pp
+++ b/manifests/compartment_log.pp
@@ -23,7 +23,7 @@ define cloudwatchlogs::compartment_log (
   validate_string($real_log_group_name)
   validate_string($multi_line_start_pattern)
 
-  concat { '/etc/awslogs/config/${name}.conf':
+  concat { "/etc/awslogs/config/${name}.conf":
     ensure         => 'present',
     owner          => 'root',
     group          => 'root',
@@ -31,7 +31,7 @@ define cloudwatchlogs::compartment_log (
     ensure_newline => true,
     warn           => true,
     require        => Package['awslogs'],
-  } ->
+  }
   concat::fragment { "cloudwatchlogs_fragment_${name}":
     target  => "/etc/awslogs/config/${name}.conf",
     content => template('cloudwatchlogs/awslogs_log.erb'),

--- a/manifests/compartment_log.pp
+++ b/manifests/compartment_log.pp
@@ -1,0 +1,40 @@
+define cloudwatchlogs::compartment_log (
+  $path            = undef,
+  $streamname      = '{instance_id}',
+  $datetime_format = '%b %d %H:%M:%S',
+  $log_group_name  = undef,
+  $multi_line_start_pattern = undef,
+
+){
+  if $path == undef {
+    $log_path = $name
+  } else {
+    $log_path = $path
+  }
+  if $log_group_name == undef {
+    $real_log_group_name = $name
+  } else {
+    $real_log_group_name = $log_group_name
+  }
+
+  validate_absolute_path($log_path)
+  validate_string($streamname)
+  validate_string($datetime_format)
+  validate_string($real_log_group_name)
+  validate_string($multi_line_start_pattern)
+
+  concat { '/etc/awslogs/config/${name}.conf':
+    ensure         => 'present',
+    owner          => 'root',
+    group          => 'root',
+    mode           => '0644',
+    ensure_newline => true,
+    warn           => true,
+    require        => Package['awslogs'],
+  } ->
+  concat::fragment { "cloudwatchlogs_fragment_${name}":
+    target  => "/etc/awslogs/config/${name}.conf",
+    content => template('cloudwatchlogs/awslogs_log.erb'),
+  }
+
+}

--- a/manifests/compartment_log.pp
+++ b/manifests/compartment_log.pp
@@ -31,10 +31,10 @@ define cloudwatchlogs::compartment_log (
     ensure_newline => true,
     warn           => true,
     require        => Package['awslogs'],
+    notify         => Service['awslogs'],
   }
   concat::fragment { "cloudwatchlogs_fragment_${name}":
     target  => "/etc/awslogs/config/${name}.conf",
     content => template('cloudwatchlogs/awslogs_log.erb'),
   }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,6 +115,12 @@ class cloudwatchlogs (
         mode           => '0644',
         ensure_newline => true,
         warn           => true,
+      } ->
+      file { '/etc/awslogs/config':
+        ensure => 'directory',
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0755',
       }
 
       concat::fragment { 'awslogs-header':
@@ -132,6 +138,10 @@ class cloudwatchlogs (
       file { '/var/awslogs/etc/awslogs.conf':
         ensure => 'link',
         target => '/etc/awslogs/awslogs.conf',
+      } ->
+      file { '/var/awslogs/etc/config':
+        ensure => 'link',
+        target => '/etc/awslogs/config',
       }
 
       if ($region == undef) {


### PR DESCRIPTION
This will allow for ${name} defined individual config files.

This can allow for a 'default' method using log.pp or compartmentalised method using compartment_log.pp