### PR TITLE
Bugfix/var awslogs etc config force

### DIFF
--- a/manifests/compartment_log.pp
+++ b/manifests/compartment_log.pp
@@ -23,6 +23,11 @@ define cloudwatchlogs::compartment_log (
   validate_string($real_log_group_name)
   validate_string($multi_line_start_pattern)
 
+  $installed_marker = $::operatingsystem ? {
+    'Amazon' => Package['awslogs'],
+    default  => Exec['cloudwatchlogs-install'],
+  }
+
   concat { "/etc/awslogs/config/${name}.conf":
     ensure         => 'present',
     owner          => 'root',
@@ -30,7 +35,7 @@ define cloudwatchlogs::compartment_log (
     mode           => '0644',
     ensure_newline => true,
     warn           => true,
-    require        => Package['awslogs'],
+    require        => $installed_marker,
     notify         => Service['awslogs'],
   }
   concat::fragment { "cloudwatchlogs_fragment_${name}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -141,6 +141,7 @@ class cloudwatchlogs (
       } ->
       file { '/var/awslogs/etc/config':
         ensure => 'link',
+        force  => true,
         target => '/etc/awslogs/config',
       }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,11 @@ class cloudwatchlogs (
     validate_string($log_level)
   }
 
+  $installed_marker = $::operatingsystem ? {
+    'Amazon' => Package['awslogs'],
+    default  => Exec['cloudwatchlogs-install'],
+  }
+
   validate_hash($logs_real)
   create_resources('cloudwatchlogs::log', $logs_real)
 
@@ -184,7 +189,7 @@ class cloudwatchlogs (
         mode    => '0644',
         content => template('cloudwatchlogs/awslogs_logging_config_file.erb'),
         notify  => Service['awslogs'],
-        require => Package['awslogs'],
+        require => $installed_marker,
     }
   }
 }


### PR DESCRIPTION
Fixes two bugs

1. Set force on creating symlinked dir in case it already exists
1. Several require's were pointed at `Package['awslogs']` which only exists on amazon linux