### PR TITLE
Set the Puppet Service Provider to Systemd for Amazon Linux 2

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,6 +87,7 @@ class cloudwatchlogs (
 
       service { $service_name:
         ensure     => 'running',
+        provider   => systemd,
         enable     => true,
         hasrestart => true,
         hasstatus  => true,


### PR DESCRIPTION
Amazon Linux 2 using Systemd to manage services