### PR TITLE
Enhancement: Add file_fingerprint_lines option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
+## 2016-12-04 - Release 3.2.1
+### Summary
+Small bugfix release.
+
+#### Bugfixes
+- Force creation of symlink at `/var/awslogs/etc/conf` to prevent issues during upgrades.
+- Add appropriate `requires` based on OS for the main config.
+
 ## 2016-07-12 - Release 2.3.0
 ### Summary
 Large feature and bug fix release.
 
-### Bugfixes
+#### Bugfixes
 - Ensure config is concated before installation.
 - Various linting & test fixes.
 
-### Features
+#### Features
 - Support for setting `cloudwatchlogs::logs` via a Hiera hash.
 - Support setting the `region` in the main `awscli` config file.
 - Support for setting the `log_level` for logs.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ Default: `undef`
 
 Optional. This is a regex string that identifies the start of a log line. See [the official docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/AgentReference.html) for further info.
 
+#### `file_fingerprint_lines`
+
+Default: `1`
+
+Optional. Specifies the range of lines for identifying a file. The valid values are one number or two dash delimited numbers, such as '1', '2-5'. The default value is '1' so the first line is used to calculate fingerprint.  Fingerprint lines are not sent to CloudWatch Logs unless all the specified lines are available. 
+
 ## Http Proxy Usage
 
 If you have a http_proxy or https_proxy then run the following puppet code after calling cloudwatchlogs to modify the launcher script as a workaround bcause awslogs python code currently doesn't have http_proxy support:

--- a/manifests/compartment_log.pp
+++ b/manifests/compartment_log.pp
@@ -1,9 +1,10 @@
 define cloudwatchlogs::compartment_log (
-  $path            = undef,
-  $streamname      = '{instance_id}',
-  $datetime_format = '%b %d %H:%M:%S',
-  $log_group_name  = undef,
+  $path                     = undef,
+  $streamname               = '{instance_id}',
+  $datetime_format          = '%b %d %H:%M:%S',
+  $log_group_name           = undef,
   $multi_line_start_pattern = undef,
+  $file_fingerprint_lines   = '1',
 
 ){
   if $path == undef {
@@ -22,6 +23,7 @@ define cloudwatchlogs::compartment_log (
   validate_string($datetime_format)
   validate_string($real_log_group_name)
   validate_string($multi_line_start_pattern)
+  validate_string($file_fingerprint_lines)
 
   $installed_marker = $::operatingsystem ? {
     'Amazon' => Package['awslogs'],

--- a/manifests/compartment_log.pp
+++ b/manifests/compartment_log.pp
@@ -4,7 +4,7 @@ define cloudwatchlogs::compartment_log (
   $datetime_format          = '%b %d %H:%M:%S',
   $log_group_name           = undef,
   $multi_line_start_pattern = undef,
-  $file_fingerprint_lines   = '1',
+  $file_fingerprint_lines   = undef,
 
 ){
   if $path == undef {

--- a/manifests/log.pp
+++ b/manifests/log.pp
@@ -4,7 +4,7 @@ define cloudwatchlogs::log (
   $datetime_format          = '%b %d %H:%M:%S',
   $log_group_name           = undef,
   $multi_line_start_pattern = undef,
-  $file_fingerprint_lines   = '1',
+  $file_fingerprint_lines   = undef,
 
 ){
   if $path == undef {

--- a/manifests/log.pp
+++ b/manifests/log.pp
@@ -1,9 +1,10 @@
 define cloudwatchlogs::log (
-  $path            = undef,
-  $streamname      = '{instance_id}',
-  $datetime_format = '%b %d %H:%M:%S',
-  $log_group_name  = undef,
+  $path                     = undef,
+  $streamname               = '{instance_id}',
+  $datetime_format          = '%b %d %H:%M:%S',
+  $log_group_name           = undef,
   $multi_line_start_pattern = undef,
+  $file_fingerprint_lines   = '1',
 
 ){
   if $path == undef {
@@ -22,6 +23,7 @@ define cloudwatchlogs::log (
   validate_string($datetime_format)
   validate_string($real_log_group_name)
   validate_string($multi_line_start_pattern)
+  validate_string($file_fingerprint_lines)
 
   concat::fragment { "cloudwatchlogs_fragment_${name}":
     target  => '/etc/awslogs/awslogs.conf',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "kemra102-cloudwatchlogs",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": "kemra102",
   "summary": "Configure AWS Cloudwatch Logs on Amazon Linux, Ubuntu, Red Hat & CentOS EC2 instances.",
   "license": "BSD-2-Clause",

--- a/templates/awslogs_log.erb
+++ b/templates/awslogs_log.erb
@@ -8,3 +8,6 @@ log_group_name = <%= @real_log_group_name %>
 <% if @multi_line_start_pattern -%>
 multi_line_start_pattern = <%= @multi_line_start_pattern %>
 <% end %>
+<% if @file_fingerprint_lines -%>
+file_fingerprint_lines = <%= @file_fingerprint_lines %>
+<% end %>

--- a/templates/awslogs_log.erb
+++ b/templates/awslogs_log.erb
@@ -10,4 +10,4 @@ multi_line_start_pattern = <%= @multi_line_start_pattern %>
 <% end -%>
 <% if @file_fingerprint_lines -%>
 file_fingerprint_lines = <%= @file_fingerprint_lines %>
-<% end -%>
+<% end %>

--- a/templates/awslogs_log.erb
+++ b/templates/awslogs_log.erb
@@ -7,7 +7,7 @@ initial_position = start_of_file
 log_group_name = <%= @real_log_group_name %>
 <% if @multi_line_start_pattern -%>
 multi_line_start_pattern = <%= @multi_line_start_pattern %>
-<% end %>
+<% end -%>
 <% if @file_fingerprint_lines -%>
 file_fingerprint_lines = <%= @file_fingerprint_lines %>
-<% end %>
+<% end -%>


### PR DESCRIPTION
Adding file fingerprint as described in the AWS documentation, but not yet available in this module.

Updated README.md and added appropriate lines to files, with formatting tweaks.

This addresses a case where the service fails to recognize file rotation when the first line of the file is an identical "banner" line causing a stale state with no new uploads going to CloudWatch.

Sample data from log file:
```
# MicroStrategy Log version 2.0
2018-10-12 15:00:00.333 [HOST: <redacted>
2018-10-12 15:00:00.342 [HOST: <redacted>
```