### PR TITLE
fix amazon linux 2 osmajor ref

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,9 +7,10 @@ class cloudwatchlogs::params {
   $osname = $facts['os']['name']
   $osmajor = $facts['os']['release']['major']
   $oslong = "${osname}${osmajor}"
-  
+
   case $oslong {
     'Amazon2': { $service_name = 'awslogsd' }
+    'Amazon4': { $service_name = 'awslogsd' } #Amazon Linux 2 returns 4 for osmajor
     default: { $service_name = 'awslogs' }
   }
   $logging_config_file = '/etc/awslogs/awslogs_dot_log.conf'


### PR DESCRIPTION
```
# facter os
{
  architecture => "x86_64",
  family => "RedHat",
  hardware => "x86_64",
  name => "Amazon",
  release => {
    full => "4.14.203-156.332.amzn2.x86_64",
    major => "4",
    minor => "14"
  },
  selinux => {
    enabled => false
  }
}
```